### PR TITLE
Clarification about env.js 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ SOEN343 - Software Design 1 - Team Project
 - Example env.js file:
     ``` 
         export const APIKey = 'api_key';
-        export const CUSTOMER_ID = 'customer_id';
-        export const CLEANER_ID = 'cleaner_id';
+        export const CUSTOMER_ID = '4';
+        export const CLEANER_ID = '1';
     ```
+    where api_key is a google Places API key (https://developers.google.com/places/web-service/get-api-key)
 ### Starting the server
 - Open a separate terminal in the wheely-clean-frontend folder
 - Enter the command "npm i"


### PR DESCRIPTION
Made the example README file more clear
- explained how to get an api key
- inserted the default values for customer and cleaner id

The motivation for this change is that someone from our team used the old sample as their `env.js` which didn't work since the sample isn't actually a valid environment configuration.